### PR TITLE
Adds rel-me to social links

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -1,7 +1,7 @@
 <ul class="list-inline mb-1 mt-2">
     {{ range .Site.Params.social.list }}
     <li class="list-inline-item ml-1 mr-1">
-        <a class="text-warning" href="{{ .url }}">
+        <a class="text-warning" href="{{ .url }}" rel="me">
             <i class="{{ .class }} {{ .icon }}" style="font-size:25px;"></i>
         </a>
     </li>


### PR DESCRIPTION
[rel="me"](https://indieweb.org/rel-me) is a commonly used way to show that that two websites or social media accounts are the same, and is used for authentication and proving site ownership in a variety of ways.