### PR TITLE
bug: fix deprecated dependency error in layouts/partials/linkCSS.html

### DIFF
--- a/layouts/partials/linkCSS.html
+++ b/layouts/partials/linkCSS.html
@@ -1,5 +1,5 @@
 {{ $css := resources.Get "main.css" }}
-{{ $css = $css | resources.PostCSS }}
+{{ $css = $css | css.PostCSS }}
 {{ if hugo.IsProduction }}
 {{ $css = $css | minify | fingerprint | resources.PostProcess }}
 {{ end }}


### PR DESCRIPTION
Fix the deprecated error in `layouts/partials/linkCSS.html` file.

**Problem**: I cloned this repository and when I run `hugo server`, the deprecated error happened and hugo could not build the page. 

- hugo version: v0.147.8
- platform: Windows 11

![error screenshot](https://github.com/user-attachments/assets/6fdd07f6-7dc7-4108-8e2d-72ff50c20e4c)

The error message says the `resources.PostCSS` was deprecated in Hugo v0.128.0 and should use `css.PostCSS` instead. 

**Fix**: replace the `resources.PostCSS` in `linkCSS.html` file with `css.PostCSS` and `hugo server` is able to render the page with no error report.
